### PR TITLE
tools: migrate to gonum.org/v1/plot

### DIFF
--- a/tools/PFODist.go
+++ b/tools/PFODist.go
@@ -11,10 +11,11 @@ import (
 	"path"
 	"time"
 
-	"github.com/gonum/plot/vg"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
 	"go-hep.org/x/hep/lcio"
+
+	"gonum.org/v1/plot/vg"
 )
 
 var (

--- a/tools/clusterDist.go
+++ b/tools/clusterDist.go
@@ -11,10 +11,11 @@ import (
 	"path"
 	"time"
 
-	"github.com/gonum/plot/vg"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
 	"go-hep.org/x/hep/lcio"
+
+	"gonum.org/v1/plot/vg"
 )
 
 var (

--- a/tools/trackEff.go
+++ b/tools/trackEff.go
@@ -11,10 +11,11 @@ import (
 	"path"
 	"time"
 
-	"github.com/gonum/plot/vg"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
 	"go-hep.org/x/hep/lcio"
+
+	"gonum.org/v1/plot/vg"
 )
 
 var (


### PR DESCRIPTION
This CL migrates all the imports of "github.com/gonum/plot..."
to the new vanity import: "gonum.org/v1/plot..."